### PR TITLE
Fix: Improve mobile responsiveness of web UI

### DIFF
--- a/views/layout.tmpl
+++ b/views/layout.tmpl
@@ -49,7 +49,7 @@
 
   <!-- Header -->
   <header class="border-b border-zinc-200 dark:border-zinc-800">
-    <div class="max-w-5xl mx-auto px-4 py-3 flex justify-between items-center">
+    <div class="mx-auto px-4 sm:px-6 lg:px-8 py-3 flex justify-between items-center">
       <h1 class="text-xl sm:text-2xl font-bold flex items-center gap-2">
         <span class="text-[1.4rem] sm:text-[1.6rem]">🩺</span> Health&nbsp;Dashboard
       </h1>
@@ -62,7 +62,7 @@
     </div>
   </header>
 
-  <main class="flex-1 max-w-5xl mx-auto px-4 py-6 sm:py-8">
+  <main class="flex-1 mx-auto px-4 sm:px-6 lg:px-8 py-6 sm:py-8">
     {{ block "content" . }}{{ end }}
   </main>
 

--- a/views/partials/weekly.tmpl
+++ b/views/partials/weekly.tmpl
@@ -1,4 +1,4 @@
-<div class="bg-white dark:bg-zinc-900 rounded-2xl shadow p-5 sm:p-6">
+<div class="bg-white dark:bg-zinc-900 rounded-2xl shadow p-5 sm:p-6 overflow-x-auto">
   <h2 class="font-semibold text-base sm:text-lg mb-4">
     Week of {{ .WeekStart.Format "2006-01-02" }}
   </h2>


### PR DESCRIPTION
The web UI was previously too wide for mobile devices due to a fixed maximum width (`max-w-5xl`) applied to the main layout.

This commit addresses the issue by:
- Removing the `max-w-5xl` constraint from the header and main content areas in `views/layout.tmpl`.
- Applying responsive padding (`px-4 sm:px-6 lg:px-8`) to these areas to ensure appropriate spacing across various screen sizes.
- Reviewing all partial templates to ensure their content is responsive.
- Adding `overflow-x-auto` to the container in `views/partials/weekly.tmpl` as a preventative measure for potential future content overflow.

These changes make the web UI adapt better to smaller screens, improving the user experience on mobile devices.