### PR TITLE
Fix: Ensure body theme changes in dark mode

### DIFF
--- a/views/layout.tmpl
+++ b/views/layout.tmpl
@@ -42,6 +42,11 @@
     :root      { --accent: #14b8a6; }         /* teal-500 for light mode */
     .dark      { --accent: #22d3ee; }         /* cyan-400 for dark mode */
     ::selection{ background: var(--accent); color: #fff; }
+
+   .dark body {
+     background-color: #09090b; /* zinc-950 */
+     color: #f4f4f5;            /* zinc-100 */
+   }
   </style>
 </head>
 


### PR DESCRIPTION
The light/dark mode toggle was only changing the accent color, not the body background or text colors. This was likely due to Tailwind's CDN not correctly applying or prioritizing the dark mode utility classes (e.g., `dark:bg-zinc-950`) on the `body` element.

This commit fixes the issue by adding explicit CSS rules within the `<style>` block in `views/layout.tmpl` for the `body` element when dark mode is active (i.e., when the `<html>` tag has the `dark` class). These rules directly set the `background-color` and `color` properties to the desired dark theme values (zinc-950 and zinc-100 respectively), ensuring the body theme updates correctly along with the accent color.