### PR TITLE
Fix: Ensure full dark mode functionality

### DIFF
--- a/views/layout.tmpl
+++ b/views/layout.tmpl
@@ -42,6 +42,23 @@
     :root      { --accent: #14b8a6; }         /* teal-500 for light mode */
     .dark      { --accent: #22d3ee; }         /* cyan-400 for dark mode */
     ::selection{ background: var(--accent); color: #fff; }
+
+   .dark body {
+     background-color: #09090b; /* zinc-950 */
+     color: #f4f4f5;            /* zinc-100 */
+   }
+
+   /* Default state (light mode): light-icon shown, dark-icon hidden */
+   .light-icon { display: inline !important; }
+   .dark-icon { display: none !important; }
+
+   /* When dark mode is active on html */
+   .dark .dark-icon { display: inline !important; }
+   .dark .light-icon { display: none !important; }
+
+   /* Explicitly for light mode (when html does NOT have .dark) */
+   html:not(.dark) .light-icon { display: inline !important; }
+   html:not(.dark) .dark-icon { display: none !important; }
   </style>
 </head>
 
@@ -56,8 +73,8 @@
       <button onclick="toggleTheme()"
               class="px-3 py-1.5 sm:py-2 rounded-lg text-sm border border-zinc-300 dark:border-zinc-700
                      hover:bg-zinc-200 dark:hover:bg-zinc-800 transition">
-        <span class="hidden dark:inline">☀️ Light</span>
-        <span class="inline dark:hidden">🌙 Dark</span>
+        <span class="light-icon">☀️ Light</span>
+        <span class="dark-icon">🌙 Dark</span>
       </button>
     </div>
   </header>


### PR DESCRIPTION
This commit addresses issues with the light/dark theme toggle where previously only the accent color would change, or later, the button text would not update.

The root cause appeared to be inconsistent application of Tailwind CSS `dark:` prefixed utility classes when using the Tailwind CDN.

The following changes ensure reliable theme switching:
1. The JavaScript correctly toggles a `dark` class on the `<html>` element.
2. Button text visibility (☀️ Light / 🌙 Dark) is now handled by direct CSS rules targeting classes (`.light-icon`, `.dark-icon`) and the presence of the `.dark` class on `<html>`. This bypasses issues with Tailwind's `dark:inline` or `dark:hidden` utilities.
3. Body background and text colors for dark mode are now also handled by explicit CSS rules (`.dark body { ... }`), ensuring they apply correctly, sidestepping reliance on Tailwind's `dark:bg-*` or `dark:text-*` utilities for the body if they are not being processed as expected.
4. Accent colors continue to work via CSS custom properties that change based on the `.dark` class on `<html>`.

This approach ensures all visual aspects of the theme (button text, accent color, body background, and body text) toggle correctly.