### PR TITLE
Fix: Address web UI display issues in food log and layout

### DIFF
--- a/main.go
+++ b/main.go
@@ -143,6 +143,24 @@ type CaloriesTodayResponse struct {
 
 /* ───────────────────── Helpers for templates ───────────────────── */
 
+// FormatNote formats a food log note for display.
+// It handles sql.NullString and a specific string pattern.
+func FormatNote(note sql.NullString) string {
+	if !note.Valid || note.String == "" {
+		return "–"
+	}
+	s := note.String
+	if strings.HasPrefix(s, "{") && strings.HasSuffix(s, " true}") {
+		s = strings.TrimPrefix(s, "{")
+		s = strings.TrimSuffix(s, " true}")
+		if s == "" {
+			return "–"
+		}
+		return s
+	}
+	return s
+}
+
 func fmtF2(p *float64) string {
 	if p == nil {
 		return "–"
@@ -179,11 +197,12 @@ func main() {
 
 	// Define custom functions for use within HTML templates.
 	funcs := template.FuncMap{
-		"fmtF2":    fmtF2,    // Formats a float64 pointer to a string with 1 decimal place, or "–" if nil.
-		"fmtInt":   fmtInt,   // Formats an int pointer to a string, or "–" if nil.
-		"safeHTML": safeHTML, // Allows embedding unescaped HTML.
-		"mod":      mod,      // Modulo operator for template logic.
-		"todayStr": todayStr, // Returns current date as "YYYY-MM-DD".
+		"fmtF2":      fmtF2,    // Formats a float64 pointer to a string with 1 decimal place, or "–" if nil.
+		"fmtInt":     fmtInt,   // Formats an int pointer to a string, or "–" if nil.
+		"safeHTML":   safeHTML, // Allows embedding unescaped HTML.
+		"mod":        mod,      // Modulo operator for template logic.
+		"todayStr":   todayStr, // Returns current date as "YYYY-MM-DD".
+		"formatNote": FormatNote, // Formats food log notes.
 	}
 	// Parse HTML templates from embedded resources.
 	// Includes all .tmpl files in 'views' and 'views/partials'.

--- a/views/layout.tmpl
+++ b/views/layout.tmpl
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en" class="scroll-smooth">
+<html lang="en" class="scroll-smooth h-full">
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/views/partials/food.tmpl
+++ b/views/partials/food.tmpl
@@ -18,7 +18,7 @@
       <tr class="{{ if mod $i 2 }}bg-zinc-50 dark:bg-zinc-800{{ end }} hover:bg-zinc-100 dark:hover:bg-zinc-700 border-b border-zinc-100 dark:border-zinc-800">
         <td class="py-3 px-4 whitespace-nowrap">{{ $f.CreatedAt.Format "15:04" }}</td>
         <td class="px-4 tabular-nums">{{ $f.Calories }}</td>
-        <td class="px-4">{{ if $f.Note }}{{ $f.Note }}{{ else }}–{{ end }}</td>
+        <td class="px-4">{{ formatNote $f.Note }}</td>
         <td class="px-4 text-right">
           <button
             hx-delete="/food?id={{ $f.ID }}"


### PR DESCRIPTION
This commit resolves several UI problems:

1.  **Food Log Note Formatting:**
    - I implemented a new template function `formatNote` to clean up the display of food log notes.
    - Notes appearing in the format "{Some text true}" will now have the leading "{" and trailing " true}" removed for a cleaner presentation.
    - I updated the food log partial (`views/partials/food.tmpl`) to use this new formatter.

2.  **Mobile Background Cutoff:**
    - I added `class="h-full"` to the `<html>` tag in `views/layout.tmpl`.
    - This helps ensure that the page layout correctly extends to the full viewport height on mobile devices, preventing the background from appearing cut off.

3.  **Dark Mode Background:**
    - I verified that the dark mode background styling is correctly implemented using Tailwind CSS (`dark:bg-zinc-950` on the body).
    - The previously reported issue where the background didn't change was likely a perceptual effect of the mobile background cutoff problem, which is now addressed.