### PR TITLE
Enhance UI styling

### DIFF
--- a/views/layout.tmpl
+++ b/views/layout.tmpl
@@ -24,7 +24,7 @@
 
 
   <style>
-    :root      { --accent: #4f46e5; }         /* indigo-600 for light mode */
+    :root      { --accent: #2563eb; }         /* blue-600 for light mode */
     .dark      { --accent: #f97316; }         /* orange-500 for dark mode */
     ::selection{ background: var(--accent); color: #fff; }
     html { transition: background-color .2s, color .2s; }
@@ -34,12 +34,12 @@
 <body class="bg-gray-50 text-gray-800 dark:bg-gray-900 dark:text-gray-100 font-sans min-h-screen flex flex-col">
 
   <!-- Header -->
-  <header class="border-b border-zinc-200 dark:border-zinc-800">
-    <div class="mx-auto px-4 sm:px-6 lg:px-8 py-3 flex justify-between items-center">
+  <header class="bg-gradient-to-r from-[var(--accent)] to-purple-600 text-white shadow">
+    <div class="mx-auto px-4 sm:px-6 lg:px-8 py-4 flex justify-between items-center max-w-5xl">
       <h1 class="text-xl sm:text-2xl font-bold flex items-center gap-2">
         <span class="text-[1.4rem] sm:text-[1.6rem]">🩺</span> Health&nbsp;Dashboard
       </h1>
-      <button id="themeToggle" class="ml-4 w-9 h-9 rounded-full flex items-center justify-center bg-gray-200 dark:bg-gray-700 hover:bg-gray-300 dark:hover:bg-gray-600 transition" aria-label="Toggle theme">
+      <button id="themeToggle" class="ml-4 w-9 h-9 rounded-full flex items-center justify-center bg-white/20 hover:bg-white/30 text-white focus:outline-none focus:ring-2 focus:ring-white transition" aria-label="Toggle theme">
         <span class="block dark:hidden">🌙</span>
         <span class="hidden dark:block">☀️</span>
       </button>
@@ -47,7 +47,9 @@
   </header>
 
   <main class="flex-1 w-full px-4 sm:px-6 lg:px-8 py-6 sm:py-8">
-    {{ block "content" . }}{{ end }}
+    <div class="max-w-5xl mx-auto space-y-6">
+      {{ block "content" . }}{{ end }}
+    </div>
   </main>
 
   <footer class="text-center text-xs text-zinc-500 py-4">

--- a/views/partials/cards.tmpl
+++ b/views/partials/cards.tmpl
@@ -1,7 +1,7 @@
 {{/* Predefined utility class strings for consistent styling */}}
 {{ $input := "flex-1 rounded-lg bg-zinc-100 dark:bg-zinc-800 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-[var(--accent)]" }}
-{{ $btn   := "px-4 py-2 rounded-lg bg-[var(--accent)] text-white shrink-0" }}
-{{ $card  := "bg-white dark:bg-zinc-900 rounded-2xl shadow shadow-zinc-200 dark:shadow-zinc-900/40 p-5 sm:p-6 space-y-3" }}
+{{ $btn   := "px-4 py-2 rounded-lg bg-[var(--accent)] text-white shrink-0 hover:bg-opacity-90 focus:outline-none focus:ring-2 focus:ring-[var(--accent)]/40 transition" }}
+{{ $card  := "bg-white dark:bg-zinc-900 rounded-2xl shadow hover:shadow-lg transition shadow-zinc-200 dark:shadow-zinc-900/40 p-5 sm:p-6 space-y-3" }}
 {{ $title := "font-semibold text-base sm:text-lg" }}
 {{ $chip  := "px-3 py-1.5 text-xs font-medium border border-zinc-300 dark:border-zinc-700 rounded-full bg-zinc-100 dark:bg-zinc-800 hover:bg-zinc-200 dark:hover:bg-zinc-700 transition" }}
 


### PR DESCRIPTION
## Summary
- add a blue accent colour and gradient header
- center content with a max width wrapper
- refine buttons and card shadows for a sleeker look

## Testing
- `npm install`
- `npm run build:css`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_6840ef0ed634832eaecd1eab03a82a61