### PR TITLE
Add weight goal projections

### DIFF
--- a/views/index.tmpl
+++ b/views/index.tmpl
@@ -10,6 +10,11 @@
     <!-- BMI trend chart card -->
     {{ template "bmi_chart.tmpl" . }}
 
+    <!-- Goal projection card -->
+    {{ if .Goals }}
+    {{ template "goals.tmpl" .Goals }}
+    {{ end }}
+
     <!-- Weekly stats card (loads via HTMX) -->
     <div class="bg-white dark:bg-zinc-900 rounded-2xl shadow shadow-zinc-200 dark:shadow-zinc-900/40 p-5 sm:p-6"
          hx-get="/weekly" hx-trigger="load every 10m" hx-swap="outerHTML">

--- a/views/partials/goals.tmpl
+++ b/views/partials/goals.tmpl
@@ -1,0 +1,27 @@
+<div class="bg-white dark:bg-zinc-900 rounded-2xl shadow p-5 sm:p-6 overflow-x-auto">
+  <h2 class="font-semibold text-base sm:text-lg mb-4">Weight Goals</h2>
+  <table class="w-full text-sm">
+    <tbody class="divide-y divide-zinc-200 dark:divide-zinc-800">
+      <tr>
+        <td class="py-2">Current</td>
+        <td class="py-2 text-right">{{ printf "%.1f" .CurrentWeight }} kg</td>
+      </tr>
+      <tr>
+        <td class="py-2">63kg milestone</td>
+        <td class="py-2 text-right">
+          {{ if .MilestoneDays }}{{ .MilestoneDays }} days
+            <span class="text-xs text-zinc-500">({{ .MilestoneDate.Format "02 Jan" }})</span>
+          {{ else }}–{{ end }}
+        </td>
+      </tr>
+      <tr>
+        <td class="py-2">60kg goal</td>
+        <td class="py-2 text-right">
+          {{ if .GoalDays }}{{ .GoalDays }} days
+            <span class="text-xs text-zinc-500">({{ .GoalDate.Format "02 Jan" }})</span>
+          {{ else }}–{{ end }}
+        </td>
+      </tr>
+    </tbody>
+  </table>
+</div>


### PR DESCRIPTION
## Summary
- compute recent weight trend and estimate days to 63kg milestone and 60kg goal
- expose projections in `PageData` and show them on the home page

## Testing
- `go build ./...`
- `npm run build:css`


------
https://chatgpt.com/codex/tasks/task_e_6840f7408ea8832e82ed64d084c0ff43