### PR TITLE
Add goal calculation details

### DIFF
--- a/main.go
+++ b/main.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"html/template"
 	"log"
+	"math"
 	"net/http"
 	"os"
 	"os/signal"
@@ -73,6 +74,21 @@ type Weekly struct {
 	TotalDeficit   *int      `json:"total_deficit,omitempty"`
 }
 
+// GoalProjection holds estimated timeframes for reaching weight goals based on
+// recent weight trends.
+type GoalProjection struct {
+	CurrentWeight    float64
+	DailyChange      float64
+	MilestoneWeight  float64
+	MilestoneDays    *int
+	MilestoneDate    *time.Time
+	MilestoneFormula string
+	GoalWeight       float64
+	GoalDays         *int
+	GoalDate         *time.Time
+	GoalFormula      string
+}
+
 // PageData is the primary data structure passed to HTML templates for rendering views.
 // It aggregates various pieces of data needed for the UI.
 type PageData struct {
@@ -80,6 +96,7 @@ type PageData struct {
 	Summary  []DailySummary
 	Food     []FoodEntry
 	QuickAdd []QuickAddItem
+	Goals    *GoalProjection
 }
 
 // WeightLogRequest defines the expected JSON payload for logging weight.
@@ -419,6 +436,88 @@ func (a *App) fetchQuickAdd(ctx context.Context) ([]QuickAddItem, error) {
 	return out, rows.Err()
 }
 
+// weightTrend calculates the average daily weight change over the last 30 days.
+// It returns the most recent weight and the change per day (positive or negative).
+// If insufficient data is available, rate will be 0.
+func (a *App) weightTrend(ctx context.Context) (current float64, rate float64, err error) {
+	rows, err := a.db.Query(ctx, `
+                SELECT log_date, weight_kg FROM (
+                        SELECT log_date, weight_kg
+                          FROM v_daily_summary
+                         WHERE user_id = 1 AND weight_kg IS NOT NULL
+                         ORDER BY log_date DESC
+                         LIMIT 30
+                ) t ORDER BY log_date`)
+	if err != nil {
+		return 0, 0, err
+	}
+	defer rows.Close()
+
+	type entry struct {
+		dt time.Time
+		w  float64
+	}
+	var data []entry
+	for rows.Next() {
+		var e entry
+		if err := rows.Scan(&e.dt, &e.w); err != nil {
+			return 0, 0, err
+		}
+		data = append(data, e)
+	}
+	if len(data) == 0 {
+		return 0, 0, nil
+	}
+	current = data[len(data)-1].w
+	if len(data) < 2 {
+		return current, 0, nil
+	}
+	first := data[0]
+	days := data[len(data)-1].dt.Sub(first.dt).Hours() / 24
+	if days == 0 {
+		return current, 0, nil
+	}
+	rate = (current - first.w) / days
+	return current, rate, nil
+}
+
+// calculateGoalProjection returns estimated dates to reach milestone and final weight goals.
+func (a *App) calculateGoalProjection(ctx context.Context, milestone, goal float64) (*GoalProjection, error) {
+	current, dailyRate, err := a.weightTrend(ctx)
+	if err != nil {
+		return nil, err
+	}
+	gp := &GoalProjection{
+		CurrentWeight:   current,
+		DailyChange:     dailyRate,
+		MilestoneWeight: milestone,
+		GoalWeight:      goal,
+	}
+	if dailyRate == 0 {
+		return gp, nil
+	}
+	now := time.Now()
+	if current > milestone && dailyRate < 0 {
+		days := int(math.Ceil((milestone - current) / dailyRate))
+		if days >= 0 {
+			t := now.Add(time.Duration(days) * 24 * time.Hour)
+			gp.MilestoneDays = &days
+			gp.MilestoneDate = &t
+			gp.MilestoneFormula = fmt.Sprintf("(%.1f - %.1f)/%.3f = %d days", milestone, current, dailyRate, days)
+		}
+	}
+	if current > goal && dailyRate < 0 {
+		days := int(math.Ceil((goal - current) / dailyRate))
+		if days >= 0 {
+			t := now.Add(time.Duration(days) * 24 * time.Hour)
+			gp.GoalDays = &days
+			gp.GoalDate = &t
+			gp.GoalFormula = fmt.Sprintf("(%.1f - %.1f)/%.3f = %d days", goal, current, dailyRate, days)
+		}
+	}
+	return gp, nil
+}
+
 // fetchSingleDaySummary retrieves the DailySummary for a specific date and user.
 // If no data exists for that date, it returns a DailySummary with only LogDate set,
 // and other fields as nil. This is not considered an error (sql.ErrNoRows is handled).
@@ -528,12 +627,18 @@ func (a *App) handleIndex(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	goals, err := a.calculateGoalProjection(ctx, 63, 60)
+	if err != nil {
+		log.Printf("Error calculating goals: %v", err)
+	}
+
 	// Prepare data for the template.
 	data := PageData{
 		Pivot:    pivot,
 		Summary:  summary,
 		Food:     foods,
 		QuickAdd: quick,
+		Goals:    goals,
 	}
 	// Render the main index template.
 	if err := a.tpl.ExecuteTemplate(w, "index.tmpl", data); err != nil {

--- a/views/index.tmpl
+++ b/views/index.tmpl
@@ -10,6 +10,11 @@
     <!-- BMI trend chart card -->
     {{ template "bmi_chart.tmpl" . }}
 
+    <!-- Goal projection card -->
+    {{ if .Goals }}
+    {{ template "goals.tmpl" .Goals }}
+    {{ end }}
+
     <!-- Weekly stats card (loads via HTMX) -->
     <div class="bg-white dark:bg-zinc-900 rounded-2xl shadow shadow-zinc-200 dark:shadow-zinc-900/40 p-5 sm:p-6"
          hx-get="/weekly" hx-trigger="load every 10m" hx-swap="outerHTML">

--- a/views/partials/goals.tmpl
+++ b/views/partials/goals.tmpl
@@ -1,0 +1,35 @@
+<div class="bg-white dark:bg-zinc-900 rounded-2xl shadow p-5 sm:p-6 overflow-x-auto relative">
+  <h2 class="font-semibold text-base sm:text-lg mb-4">Weight Goals</h2>
+  <details class="absolute top-2 right-2 text-xs">
+    <summary class="cursor-pointer select-none">?</summary>
+    <div class="mt-2 p-2 bg-zinc-50 dark:bg-zinc-800 rounded shadow w-64 space-y-1">
+      <p>Trend: {{ printf "%.3f" .DailyChange }} kg/day</p>
+      {{ if .MilestoneDays }}<p>{{ .MilestoneFormula }}</p>{{ end }}
+      {{ if .GoalDays }}<p>{{ .GoalFormula }}</p>{{ end }}
+    </div>
+  </details>
+  <table class="w-full text-sm">
+    <tbody class="divide-y divide-zinc-200 dark:divide-zinc-800">
+      <tr>
+        <td class="py-2">Current</td>
+        <td class="py-2 text-right">{{ printf "%.1f" .CurrentWeight }} kg</td>
+      </tr>
+      <tr>
+        <td class="py-2">63kg milestone</td>
+        <td class="py-2 text-right">
+          {{ if .MilestoneDays }}{{ .MilestoneDays }} days
+            <span class="text-xs text-zinc-500">({{ .MilestoneDate.Format "02 Jan" }})</span>
+          {{ else }}–{{ end }}
+        </td>
+      </tr>
+      <tr>
+        <td class="py-2">60kg goal</td>
+        <td class="py-2 text-right">
+          {{ if .GoalDays }}{{ .GoalDays }} days
+            <span class="text-xs text-zinc-500">({{ .GoalDate.Format "02 Jan" }})</span>
+          {{ else }}–{{ end }}
+        </td>
+      </tr>
+    </tbody>
+  </table>
+</div>


### PR DESCRIPTION
## Summary
- store daily trend and formulas in `GoalProjection`
- show calculations in a collapsible section of the weight goals card

## Testing
- `go build ./...`
- `npm run build:css`


------
https://chatgpt.com/codex/tasks/task_e_6840f7408ea8832e82ed64d084c0ff43