### PR TITLE
Add /api/food endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,22 @@ This section details the available API endpoints for interacting with the Health
     }
     ```
 
+### `GET /api/food`
+
+*   **Description:** Retrieves all food entries logged for the current day.
+*   **Request Parameters:** None.
+*   **Example JSON Response:**
+    ```json
+    [
+        {
+            "id": 1,
+            "created_at": "2023-10-28T12:00:00Z",
+            "calories": 250,
+            "note": "Banana"
+        }
+    ]
+    ```
+
 ### `GET /api/summary/weekly`
 
 *   **Description:** Retrieves a weekly summary of key statistics.

--- a/generated_openapi_schema.json
+++ b/generated_openapi_schema.json
@@ -263,6 +263,33 @@
         }
       }
     },
+    "/api/food": {
+      "get": {
+        "summary": "Get today's food entries",
+        "operationId": "getFood",
+        "responses": {
+          "200": {
+            "description": "List of food entries for today",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/FoodEntry"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Error retrieving food entries",
+            "content": {
+              "application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}
+            }
+          }
+        }
+      }
+    },
     "/api/summary/weekly": {
       "get": {
         "summary": "Get weekly summary of metrics",
@@ -425,6 +452,15 @@
           "total_estimated": { "type": "integer", "nullable": true, "description": "Total estimated calories burned for the week." },
           "total_budgeted": { "type": "integer", "nullable": true, "description": "Total budgeted calorie intake for the week." },
           "total_deficit": { "type": "integer", "nullable": true, "description": "Total calorie deficit for the week." }
+        }
+      },
+      "FoodEntry": {
+        "type": "object",
+        "properties": {
+          "id": { "type": "integer" },
+          "created_at": { "type": "string", "format": "date-time" },
+          "calories": { "type": "integer" },
+          "note": { "type": "string", "nullable": true }
         }
       },
       "FoodForm": {


### PR DESCRIPTION
## Summary
- expose food logs via `/api/food`
- document new endpoint in README
- extend OpenAPI schema

## Testing
- `go vet ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_684108697db8832e93b0335101fe4656