### PR TITLE
Fix HTMX trigger parse error

### DIFF
--- a/views/index.tmpl
+++ b/views/index.tmpl
@@ -17,7 +17,7 @@
 
     <!-- Weekly stats card (loads via HTMX) -->
     <div class="bg-white dark:bg-zinc-900 rounded-2xl shadow shadow-zinc-200 dark:shadow-zinc-900/40 p-5 sm:p-6"
-         hx-get="/weekly" hx-trigger="load every 10m" hx-swap="outerHTML">
+         hx-get="/weekly" hx-trigger="load, every 10m" hx-swap="outerHTML">
       Loading weekly stats…
     </div>
 


### PR DESCRIPTION
## Summary
- fix syntax for `hx-trigger` on weekly stats card

## Testing
- `go build ./...`
- `npm run build:css`

------
https://chatgpt.com/codex/tasks/task_e_68426fae012c832e9d7d5621c2e8afae