### PR TITLE
Add customizable summary columns

### DIFF
--- a/views/index.tmpl
+++ b/views/index.tmpl
@@ -4,6 +4,18 @@
 <div class="grid grid-cols-1 gap-6 sm:gap-8 md:grid-cols-3">
   <!-- Main content: data tables and charts -->
   <div class="space-y-8 md:col-span-3">
+    <!-- Column selector -->
+    <div class="bg-white dark:bg-zinc-900 rounded-2xl shadow shadow-zinc-200 dark:shadow-zinc-900/40 p-4">
+      <h2 class="font-semibold text-base sm:text-lg mb-2">Select Columns</h2>
+      <form id="columnForm" class="grid grid-cols-2 gap-x-4 gap-y-2 text-sm">
+        <label class="flex items-center"><input type="checkbox" data-col="weight" class="mr-2">Weight</label>
+        <label class="flex items-center"><input type="checkbox" data-col="kcal" class="mr-2">kcal est / bud</label>
+        <label class="flex items-center"><input type="checkbox" data-col="netkcal" class="mr-2">Net Kcal</label>
+        <label class="flex items-center"><input type="checkbox" data-col="mood" class="mr-2">Mood</label>
+        <label class="flex items-center"><input type="checkbox" data-col="activity" class="mr-2">Activity</label>
+      </form>
+    </div>
+
     <!-- Daily summary table -->
     {{ template "summary_partial.tmpl" .Summary }}
 

--- a/views/layout.tmpl
+++ b/views/layout.tmpl
@@ -62,12 +62,32 @@
 
   <!-- Custom script: auto-scroll behavior for panels -->
   <script>
+    function applyColumnPrefs() {
+      const form = document.getElementById('columnForm');
+      if (!form) return;
+      const allCols = Array.from(form.querySelectorAll('input')).map(i => i.dataset.col);
+      const saved = JSON.parse(localStorage.getItem('pivotColumns') || 'null') || allCols;
+      form.querySelectorAll('input').forEach(cb => {
+        cb.checked = saved.includes(cb.dataset.col);
+      });
+      allCols.forEach(col => {
+        const visible = saved.includes(col);
+        document.querySelectorAll('.col-' + col).forEach(el => {
+          el.style.display = visible ? '' : 'none';
+        });
+      });
+    }
+
     document.body.addEventListener('htmx:afterSwap', (e) => {
       if (e.detail.target.id === 'foodList') {
         // After food list updates, scroll it to bottom
         e.detail.target.scrollTop = e.detail.target.scrollHeight;
       }
+      if (e.detail.target.id === 'summary') {
+        applyColumnPrefs();
+      }
     });
+
     document.addEventListener('DOMContentLoaded', () => {
       const summaryEl = document.getElementById('summary');
       if (summaryEl) {
@@ -82,6 +102,15 @@
           localStorage.setItem('theme', root.classList.contains('dark') ? 'dark' : 'light');
         });
       }
+      const form = document.getElementById('columnForm');
+      if (form) {
+        form.addEventListener('change', () => {
+          const selected = Array.from(form.querySelectorAll('input:checked')).map(cb => cb.dataset.col);
+          localStorage.setItem('pivotColumns', JSON.stringify(selected));
+          applyColumnPrefs();
+        });
+      }
+      applyColumnPrefs();
     });
   </script>
 </body>

--- a/views/partials/daily_summary.tmpl
+++ b/views/partials/daily_summary.tmpl
@@ -1,35 +1,35 @@
 <table class="w-full text-sm border-collapse">
   <thead class="sticky top-0 backdrop-blur bg-white/70 dark:bg-zinc-950/70">
     <tr class="border-b border-zinc-200 dark:border-zinc-800 text-left">
-      <th class="py-3 px-4">Date</th>
-      <th class="px-4">Weight</th>
-      <th class="px-4">kcal est / bud</th>
-      <th class="px-4">Net Kcal</th>
-      <th class="px-4">Mood</th>
-      <th class="px-4">Activity</th>
+      <th class="py-3 px-4 col-date">Date</th>
+      <th class="px-4 col-weight">Weight</th>
+      <th class="px-4 col-kcal">kcal est / bud</th>
+      <th class="px-4 col-netkcal">Net Kcal</th>
+      <th class="px-4 col-mood">Mood</th>
+      <th class="px-4 col-activity">Activity</th>
     </tr>
   </thead>
   <tbody>
     {{ range $i, $row := . }}
     {{ $isToday := eq ($row.LogDate.Format "2006-01-02") (todayStr) }}
     <tr class="{{ if $isToday }}bg-[var(--accent)] text-white dark:text-black font-medium{{ else }}{{ if mod $i 2 }}bg-zinc-50 dark:bg-zinc-900{{ end }} hover:bg-zinc-100 dark:hover:bg-zinc-800{{ end }} border-b border-zinc-100 dark:border-zinc-800">
-      <td class="py-3 px-4 whitespace-nowrap" {{ if $isToday }}aria-current="date"{{ end }}>
+      <td class="py-3 px-4 whitespace-nowrap col-date" {{ if $isToday }}aria-current="date"{{ end }}>
         {{ $row.LogDate.Format "02 Jan" }}
       </td>
-      <td class="px-4 tabular-nums">{{ fmtF2 $row.WeightKg }}kg</td>
-      <td class="px-4 tabular-nums">
+      <td class="px-4 tabular-nums col-weight">{{ fmtF2 $row.WeightKg }}kg</td>
+      <td class="px-4 tabular-nums col-kcal">
         {{ if $row.KcalEstimated }}{{ fmtInt $row.KcalEstimated }}{{ end }}
         {{ if $row.KcalBudgeted }} / {{ fmtInt $row.KcalBudgeted }}{{ end }}
       </td>
-      <td class="px-4 tabular-nums">
+      <td class="px-4 tabular-nums col-netkcal">
         {{ if and $row.KcalEstimated $row.KcalBudgeted }}
           {{ printf "%+d" (sub (or $row.KcalEstimated 0) (or $row.KcalBudgeted 0)) }}
         {{ else }}
           –
         {{ end }}
       </td>
-      <td class="px-4 tabular-nums">{{ fmtInt $row.Mood }}</td>
-      <td class="px-4 tabular-nums">{{ fmtInt $row.TotalActivityMin }}</td>
+      <td class="px-4 tabular-nums col-mood">{{ fmtInt $row.Mood }}</td>
+      <td class="px-4 tabular-nums col-activity">{{ fmtInt $row.TotalActivityMin }}</td>
     </tr>
     {{ end }}
   </tbody>


### PR DESCRIPTION
## Summary
- add 'Select Columns' card to choose visible pivot table columns
- tag table headers and cells with column classes
- hide/show columns from localStorage preferences

## Testing
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_6842d38e5300832ea46436b10b8924f1