### PR TITLE
Add sleep column and refine pivot defaults

### DIFF
--- a/views/index.tmpl
+++ b/views/index.tmpl
@@ -8,11 +8,12 @@
     <div class="bg-white dark:bg-zinc-900 rounded-2xl shadow shadow-zinc-200 dark:shadow-zinc-900/40 p-4">
       <h2 class="font-semibold text-base sm:text-lg mb-2">Select Columns</h2>
       <form id="columnForm" class="grid grid-cols-2 gap-x-4 gap-y-2 text-sm">
-        <label class="flex items-center"><input type="checkbox" data-col="weight" class="mr-2">Weight</label>
-        <label class="flex items-center"><input type="checkbox" data-col="kcal" class="mr-2">kcal est / bud</label>
-        <label class="flex items-center"><input type="checkbox" data-col="netkcal" class="mr-2">Net Kcal</label>
-        <label class="flex items-center"><input type="checkbox" data-col="mood" class="mr-2">Mood</label>
-        <label class="flex items-center"><input type="checkbox" data-col="activity" class="mr-2">Activity</label>
+        <label class="flex items-center"><input type="checkbox" data-col="weight" class="h-3 w-3 text-[var(--accent)] border-gray-300 rounded mr-2" checked>Weight</label>
+        <label class="flex items-center"><input type="checkbox" data-col="kcal" class="h-3 w-3 text-[var(--accent)] border-gray-300 rounded mr-2">kcal est / bud</label>
+        <label class="flex items-center"><input type="checkbox" data-col="netkcal" class="h-3 w-3 text-[var(--accent)] border-gray-300 rounded mr-2" checked>Net Kcal</label>
+        <label class="flex items-center"><input type="checkbox" data-col="mood" class="h-3 w-3 text-[var(--accent)] border-gray-300 rounded mr-2">Mood</label>
+        <label class="flex items-center"><input type="checkbox" data-col="activity" class="h-3 w-3 text-[var(--accent)] border-gray-300 rounded mr-2">Activity</label>
+        <label class="flex items-center"><input type="checkbox" data-col="sleep" class="h-3 w-3 text-[var(--accent)] border-gray-300 rounded mr-2">Sleep</label>
       </form>
     </div>
 

--- a/views/layout.tmpl
+++ b/views/layout.tmpl
@@ -66,7 +66,8 @@
       const form = document.getElementById('columnForm');
       if (!form) return;
       const allCols = Array.from(form.querySelectorAll('input')).map(i => i.dataset.col);
-      const saved = JSON.parse(localStorage.getItem('pivotColumns') || 'null') || allCols;
+      const defaultCols = ['netkcal', 'weight'];
+      const saved = JSON.parse(localStorage.getItem('pivotColumns') || 'null') || defaultCols;
       form.querySelectorAll('input').forEach(cb => {
         cb.checked = saved.includes(cb.dataset.col);
       });

--- a/views/partials/daily_summary.tmpl
+++ b/views/partials/daily_summary.tmpl
@@ -7,6 +7,7 @@
       <th class="px-4 col-netkcal">Net Kcal</th>
       <th class="px-4 col-mood">Mood</th>
       <th class="px-4 col-activity">Activity</th>
+      <th class="px-4 col-sleep">Sleep</th>
     </tr>
   </thead>
   <tbody>
@@ -30,6 +31,7 @@
       </td>
       <td class="px-4 tabular-nums col-mood">{{ fmtInt $row.Mood }}</td>
       <td class="px-4 tabular-nums col-activity">{{ fmtInt $row.TotalActivityMin }}</td>
+      <td class="px-4 tabular-nums col-sleep">{{ fmtInt $row.SleepDuration }}</td>
     </tr>
     {{ end }}
   </tbody>


### PR DESCRIPTION
## Summary
- tweak column selector with compact checkboxes
- default pivot columns to Net Kcal and Weight
- support optional Sleep column in summary table

## Testing
- `npm run build:css`
- `go vet ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_6842d555a57c832ea178fa4e8d89625b