### PR TITLE
Add CI workflow for Tailwind build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,33 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+      - name: Install node dependencies
+        run: npm ci
+      - name: Build Tailwind CSS
+        run: npm run build:css
+      - name: Upload built assets
+        uses: actions/upload-artifact@v4
+        with:
+          name: static-assets
+          path: static/css/app.css
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.22'
+      - name: Run Go tests
+        run: go test ./...

--- a/README.md
+++ b/README.md
@@ -279,6 +279,8 @@ When running on your MCP server, the base URL is `https://mcp.taildb558.ts.net` 
         npm run build:css
         ```
     *   This generates `static/css/app.css` which is served by the Go app.
+    *   A GitHub Actions workflow also runs `npm run build:css` on every push so
+        the compiled CSS is always up-to-date for deployments.
 
 5.  **Build and Run the Go Application:**
     *   From the root of the project directory:


### PR DESCRIPTION
## Summary
- automate Tailwind CSS compilation in a GitHub Actions workflow
- mention the automated CSS build in the README

## Testing
- `npm install`
- `npm run build:css`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_684386d68090832ea279341963e1ef64