### PR TITLE
Add detailed error messages

### DIFF
--- a/response.go
+++ b/response.go
@@ -1,0 +1,13 @@
+package main
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+)
+
+// respondErr logs the given error and sends an HTTP error response including the details.
+func respondErr(w http.ResponseWriter, status int, msg string, err error) {
+	logger.Error(strings.ToLower(msg), "err", err)
+	http.Error(w, fmt.Sprintf("%s: %v", msg, err), status)
+}


### PR DESCRIPTION
## Summary
- add helper for sending detailed HTTP errors
- show database errors directly in the UI for index, food, BMI and weekly handlers

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68438e8567b4832ebf892f2041de8516