### PR TITLE
Fix login error when Error field missing

### DIFF
--- a/handlers.go
+++ b/handlers.go
@@ -623,7 +623,8 @@ func (a *App) handleGetWeeklySummary(w http.ResponseWriter, r *http.Request) {
 func (a *App) handleLogin(w http.ResponseWriter, r *http.Request) {
 	switch r.Method {
 	case http.MethodGet:
-		_ = a.tpl.ExecuteTemplate(w, "login.tmpl", nil)
+		data := struct{ Error string }{}
+		_ = a.tpl.ExecuteTemplate(w, "login.tmpl", data)
 	case http.MethodPost:
 		if err := r.ParseForm(); err != nil {
 			http.Error(w, "bad form", http.StatusBadRequest)


### PR DESCRIPTION
## Summary
- avoid missing field error when rendering the login page by always passing a struct with an `Error` field

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_684394277bec832e8cf2a33d949d0120