### PR TITLE
Fix API routes after PIN auth

### DIFF
--- a/middleware.go
+++ b/middleware.go
@@ -7,17 +7,19 @@ import (
 
 func pinAuthMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		// Allow unauthenticated access for API endpoints and static assets.
-		if strings.HasPrefix(r.URL.Path, "/api/") || strings.HasPrefix(r.URL.Path, "/static/") || r.URL.Path == "/login" {
+		// Publicly accessible paths
+		if r.URL.Path == "/login" || strings.HasPrefix(r.URL.Path, "/api/") || strings.HasPrefix(r.URL.Path, "/static/") {
 			next.ServeHTTP(w, r)
 			return
 		}
 
-		// For UI pages, check the PIN cookie and redirect to login if missing or incorrect.
-		c, err := r.Cookie("pin")
-		if err != nil || c.Value != "1234" {
-			http.Redirect(w, r, "/login", http.StatusSeeOther)
-			return
+		// Only protect the main dashboard page
+		if r.Method == http.MethodGet && r.URL.Path == "/" {
+			c, err := r.Cookie("pin")
+			if err != nil || c.Value != "1234" {
+				http.Redirect(w, r, "/login", http.StatusSeeOther)
+				return
+			}
 		}
 
 		next.ServeHTTP(w, r)


### PR DESCRIPTION
## Summary
- avoid PIN redirect for non-dashboard pages

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6843c718e54c832eabdf93326e53af38